### PR TITLE
Update to hubot slack4

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,7 +42,7 @@ default['incident_bot'].tap do |bot|
 end
 
 default['incident_bot']['dependencies'] = {
-  "hubot-slack" => ">=3.4.2",
+  "hubot-slack" => ">=4.0.2",
   "hubot-redis-brain" => "0.0.3",
   "hubot-pager-me" => "2.1.13",
   "hubot-help" => ">=0.1.2",

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'atat@hearst.com'
 license 'All rights reserved'
 description 'Installs/Configures the Hearst Incident Bot'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.1'
+version '1.0.2'
 
 supports 'ubuntu', '>= 10.04'
 


### PR DESCRIPTION
Update to use hubot-slack version 4.0.2 for stability through the nightly Slack Team migrations.
